### PR TITLE
Add relative redirect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.4 (1/17/2017)
+* Handle relative redirects
+
 ### 1.0.3 (12/4/2017)
 * Use `frozen_string_literal` pragma in all ruby files
 * Handle new ruby 2.5 behavior when encountering newlines in header names

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -125,6 +125,8 @@ class SsrfFilter
         case response
         when ::Net::HTTPRedirection then
           url = response['location']
+          # Handle relative redirects
+          url = "#{uri.scheme}://#{hostname}:#{uri.port}#{url}" if url.start_with?('/')
         else
           return response
         end

--- a/lib/ssrf_filter/version.rb
+++ b/lib/ssrf_filter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SsrfFilter
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end


### PR DESCRIPTION
While loading content, a server can send back a `Location` header that
just includes a URL path, indicating that the same server should be
contacted again, just with a different resource. This was previously
unsupported, so this adds the ability to handle these types of
redirects.