### PR TITLE
Change Host header port rules slightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### 1.0.4 (1/17/2017)
+### 1.0.5 (1/17/2018)
+* Don't send the port number in the Host header if it's HTTPS and on port 443
+
+### 1.0.4 (1/17/2018)
 * Handle relative redirects
 
 ### 1.0.3 (12/4/2017)

--- a/lib/ssrf_filter/version.rb
+++ b/lib/ssrf_filter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SsrfFilter
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end


### PR DESCRIPTION
RFC2616 states that Host headers should include the port, but:

> A "host" without any trailing port information implies the default port
> for the service requested (e.g., "80" for an HTTP URL).

Previously ssrf_filter would only conceal the port if it was 80, but it
should also do this for port 443 if the service is HTTPS. This was
leading to infinite redirects in some cases where web servers with HTTPS
would not accept <server name>:443 as a valid hostname, leading to a
redirect.