### PR TITLE
Add support for streaming response bodies

### DIFF
--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -194,7 +194,13 @@ class SsrfFilter
 
     with_forced_hostname(hostname) do
       ::Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
-        http.request(request)
+        if options.key?(:stream)
+          http.request(request) do |response|
+            stream.call(response) unless response.is_a?(Net::HTTPRedirection)
+          end
+        else
+          http.request(request)
+        end
       end
     end
   end

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -196,7 +196,7 @@ class SsrfFilter
       ::Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
         if options.key?(:stream)
           http.request(request) do |response|
-            stream.call(response) unless response.is_a?(Net::HTTPRedirection)
+            options[:stream].call(response) unless response.is_a?(Net::HTTPRedirection)
           end
         else
           http.request(request)


### PR DESCRIPTION
This PR adds a `:stream` (Proc) option which can be used to [stream response bodies](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Streaming+Response+Bodies) or validate responses while the request has not finished yet.