### PR TITLE
Test against Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - ruby-2.5
   - ruby-2.6
   - ruby-2.7
+  - ruby-3.0
   - ruby-head
 script:
   - bundle exec bundler-audit

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This gem provides a safe and easy way to fetch content from user-submitted urls.
 - handles URIs/IPv4/IPv6, redirects, DNS, etc, correctly
 - has 0 runtime dependencies
 - has a comprehensive test suite (100% code coverage)
-- is tested against ruby `2.0`, `2.1`, `2.2`, `2.3`, `2.4`, `2.5`, `2.6`, `2.7`, and `ruby-head`
+- is tested against ruby `2.0`, `2.1`, `2.2`, `2.3`, `2.4`, `2.5`, `2.6`, `2.7`, `3.0`, and `ruby-head`
 
 ### Quick start
 

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -172,7 +172,7 @@ describe SsrfFilter do
     it 'should disallow header values with newlines and carriage returns' do
       # Starting in ruby 2.5, assigning a header value with newlines throws an ArgumentError
       major, minor = RUBY_VERSION.scan(/\A(\d+)\.(\d+)\.\d+\Z/).first.map(&:to_i)
-      exception = major >= 2 && minor >= 5 ? ArgumentError : SsrfFilter::CRLFInjection
+      exception = major >= 3 || (major >= 2 && minor >= 5) ? ArgumentError : SsrfFilter::CRLFInjection
 
       expect do
         SsrfFilter.get("https://#{public_ipv4}", headers: {'name' => "val\nue"})
@@ -419,7 +419,7 @@ describe SsrfFilter do
     it 'should follow redirects and succeed on a public hostname' do
       stub_request(:post, "https://#{public_ipv4}/path?key=value").with(headers: {host: 'www.example.com'})
         .to_return(status: 301, headers: {location: 'https://www.example2.com/path2?key2=value2'})
-      stub_request(:post, "https://#{public_ipv6}/path2?key2=value2")
+      stub_request(:post, "https://[#{public_ipv6}]/path2?key2=value2")
         .with(headers: {host: 'www.example2.com'}).to_return(status: 200, body: 'response body')
       resolver = proc do |hostname|
         [{

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -20,9 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
   gem.add_development_dependency('rspec', '~> 3.8.0')
-  gem.add_development_dependency('webmock', '~> 3.5.1')
-
-  raise 'Unsupported version of ruby' unless major == 2
+  gem.add_development_dependency('webmock', '>= 3.5.1')
+  gem.add_development_dependency('webrick') if major >= 3
 
   if minor > 1
     gem.add_development_dependency('rubocop', '~> 0.65.0')


### PR DESCRIPTION
Hello!
I'm a maintainer of the file upload library [CarrierWave](https://github.com/carrierwaveuploader/carrierwave), we use this project ssrf_filter to mitigate SSRF vulnerability. Thanks for creating and maintaining this library.

Though it runs without issues in Ruby 3.0, I noticed that it is not tested against Ruby 3.0 yet. So I've made some changes to make RSpec runnable.

It would be great if you could review this. Thanks in advance!