### PR TITLE
Add SsrfFilter#open_uri which comes with OpenURI compatible interface

### DIFF
--- a/lib/ssrf_filter.rb
+++ b/lib/ssrf_filter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ssrf_filter/open_uri'
 require 'ssrf_filter/patch/http_generic_request'
 require 'ssrf_filter/patch/ssl_socket'
 require 'ssrf_filter/ssrf_filter'

--- a/lib/ssrf_filter/open_uri.rb
+++ b/lib/ssrf_filter/open_uri.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class SsrfFilter
+  class OpenURI
+    def self.open_uri(name, *rest, &block)
+      require 'open-uri'
+
+      uri = name.is_a?(URI::Generic) ? name : URI.parse(name)
+      options = parse_arguments(rest)
+
+      response = SsrfFilter.get(uri, options) do |request|
+        uri = request.uri
+      end
+
+      buf = ::OpenURI::Buffer.new
+      buf.io.status = [response.code, response.message]
+      raise ::OpenURI::HTTPError.new(buf.io.status.join(' '), buf.io) unless response.is_a? Net::HTTPSuccess
+
+      response.read_body do |segment|
+        buf << segment
+      end
+      io = buf.io
+
+      io.rewind
+      io.base_uri = uri
+      response.each_name do |header_name|
+        if io.respond_to?(:meta_add_field2)
+          io.meta_add_field2 header_name, response.get_fields(header_name)
+        else
+          io.meta_add_field header_name, response.get_fields(header_name).join(', ')
+        end
+      end
+
+      if block_given?
+        yield_with_io(io, &block)
+      else
+        io
+      end
+    end
+
+    def self.parse_arguments(rest)
+      _, _, rest = ::OpenURI.scan_open_optional_arguments(*rest)
+      options = rest.shift if !rest.empty? && rest.first.is_a?(Hash)
+      raise ArgumentError, 'extra arguments' unless rest.empty?
+
+      options ||= {}
+      validate_options!(options)
+      options[:headers] ||= {}
+      options.each do |key, value|
+        next unless key.is_a?(String)
+
+        options[:headers][key] = value
+        options.delete(key)
+      end
+
+      options
+    end
+    private_class_method :parse_arguments
+
+    def self.validate_options!(options)
+      unsupported = %i[proxy proxy_http_basic_authentication progress_proc content_length_proc
+                       http_basic_authentication read_timeout open_timeout ssl_ca_cert ssl_verify_mode
+                       ftp_active_mode redirect encoding]
+      given = options.keys.select { |key| key.is_a?(Symbol) } & unsupported
+      raise ArgumentError, "Unsupported OpenURI option(s): #{given.join(', ')}" unless given.empty?
+    end
+    private_class_method :validate_options!
+
+    def self.yield_with_io(io)
+      yield io
+    ensure
+      if io.respond_to? :close!
+        io.close! # Tempfile
+      else
+        io.close unless io.closed?
+      end
+    end
+    private_class_method :yield_with_io
+  end
+end

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -140,6 +140,10 @@ class SsrfFilter
     end
   end
 
+  def self.open_uri(name, *rest, &block)
+    ::SsrfFilter::OpenURI.open_uri(name, *rest, &block)
+  end
+
   def self.unsafe_ip_address?(ip_address)
     return true if ipaddr_has_mask?(ip_address)
 

--- a/spec/lib/open_uri_spec.rb
+++ b/spec/lib/open_uri_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+describe SsrfFilter::OpenURI do
+  let(:public_ipv4) { IPAddr.new('172.217.6.78') }
+
+  context 'open_uri' do
+    it 'can be called in a OpenURI-compatible way' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'}).to_return(status: [200, 'OK'], body: 'response body')
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      expect(response.status).to eq(%w[200 OK])
+      expect(response.read).to eq('response body')
+    end
+
+    it 'accepts request headers' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com', accept: 'application/json'})
+        .to_return(status: [200, 'OK'], body: 'response body')
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com', 'Accept' => 'application/json')
+      expect(response.status).to eq(%w[200 OK])
+    end
+
+    it 'raises ArgumentError when unsupported OpenURI option is given' do
+      expect do
+        SsrfFilter::OpenURI.open_uri('https://www.example.com', http_basic_authentication: %w[user pass])
+      end.to raise_error ArgumentError, 'Unsupported OpenURI option(s): http_basic_authentication'
+    end
+
+    it 'can be called with a block' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'}).to_return(status: [200, 'OK'], body: 'response body')
+      expect do |block|
+        SsrfFilter::OpenURI.open_uri('https://www.example.com', &block)
+      end.to yield_with_args(OpenURI::Meta)
+    end
+
+    it 'closes Tempfile after execution of given block' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'}).to_return(status: [200, 'OK'], body: 'a' * 10241)
+      tempfile = nil
+      SsrfFilter::OpenURI.open_uri('https://www.example.com') do |io|
+        expect(io).to be_a Tempfile
+        tempfile = io
+      end
+      expect(tempfile).to be_closed
+    end
+
+    it 'returns an OpenURI::Meta instance' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'})
+        .to_return(status: [200, 'OK'], body: 'response body',
+                   headers: {'Content-Type' => 'text/plain', 'Cache-Control' => 'private'})
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      expect(response).to be_a OpenURI::Meta
+      expect(response.content_type).to eq('text/plain')
+      if response.respond_to?(:metas)
+        expect(response.metas).to eq('cache-control' => ['private'], 'content-type' => ['text/plain'])
+      end
+    end
+
+    it 'works even if OpenURI::Meta does not have #meta_add_field2 (Ruby <= 2.0)' do
+      allow_any_instance_of(OpenURI::Meta).to receive(:respond_to?).with(:meta_add_field2).and_return(false)
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'})
+        .to_return(status: [200, 'OK'], body: 'response body',
+                   headers: {'Set-Cookie' => ['foo=bar', 'baz=qux']})
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      expect(response.meta).to eq('set-cookie' => 'baz=qux, foo=bar')
+    end
+
+    it 'uses Tempfile as IO when the response is large' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'})
+        .to_return(status: [200, 'OK'], body: 'a' * 10241,
+                   headers: {'Content-Type' => 'text/plain', 'Cache-Control' => 'private'})
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      expect(response).to be_a Tempfile
+    end
+
+    it 'follows redirects and sets the final url to #base_uri' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'})
+        .to_return(status: [302, 'Found'], headers: {'Location' => 'https://www.example.com/redirected'})
+      stub_request(:get, "https://#{public_ipv4}/redirected")
+        .with(headers: {host: 'www.example.com'}).to_return(status: [200, 'OK'], body: 'response body')
+      response = SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      expect(response.status).to eq(%w[200 OK])
+      expect(response.read).to eq('response body')
+      expect(response.base_uri).to eq(URI("https://#{public_ipv4}/redirected"))
+    end
+
+    it 'raises OpenURI::HTTPError on failure' do
+      allow(SsrfFilter::DEFAULT_RESOLVER).to receive(:call).and_return([public_ipv4])
+      stub_request(:get, "https://#{public_ipv4}/")
+        .with(headers: {host: 'www.example.com'}).to_return(status: [404, 'Not Found'])
+      expect do
+        SsrfFilter::OpenURI.open_uri('https://www.example.com')
+      end.to raise_error OpenURI::HTTPError, '404 Not Found'
+    end
+  end
+end

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -447,4 +447,11 @@ describe SsrfFilter do
       expect(response.body).to eq('response body')
     end
   end
+
+  context 'open_uri' do
+    it 'invokes SsrfFilter::OpenURI#open_uri' do
+      expect(SsrfFilter::OpenURI).to receive(:open_uri).with('https://www.example.com', 'Accept' => 'application/json')
+      SsrfFilter.open_uri('https://www.example.com', 'Accept' => 'application/json')
+    end
+  end
 end


### PR DESCRIPTION
This is a feature proposal. 

I've implemented a new method `#open_uri` to SsrfFilter, which has Ruby's OpenURI compatible interface. It can be useful for people who have existing code which relies on OpenURI heavily, but need to make it SSRF proof.
(I actually experienced this situation in https://github.com/carrierwaveuploader/carrierwave/commit/012702eb3ba1663452aa025831caa304d1a665c0, and I needed to make the existing implementation compatible with both Net::HTTP and OpenURI style interfaces.)

Any suggestions and feedbacks will be appreciated. Thanks!