### PR TITLE
Add explicit proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options hash:
 - `:scheme_whitelist` — an array of schemes to allow. Defaults to `%w[http https]`.
 - `:resolver` — a proc that receives a hostname string and returns an array of [IPAddr](https://ruby-doc.org/stdlib-2.4.1/libdoc/ipaddr/rdoc/IPAddr.html) objects. Defaults to resolving with Ruby's [Resolv](https://ruby-doc.org/stdlib-2.4.1/libdoc/resolv/rdoc/Resolv.html). See examples below for a custom resolver.
 - `:max_redirects` — Maximum number of redirects to follow. Defaults to 10.
+- `:proxy` — An explicit HTTP proxy address. Defaults to `ENV['HTTP_PROXY']`.
 - `:params` — Hash of params to send with the request.
 - `:headers` — Hash of headers to send with the request.
 - `:body` — Body to send with the request.

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -127,13 +127,20 @@ describe SsrfFilter do
     end
 
     it 'should not use tls for http urls' do
-      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 80, use_ssl: false)
+      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 80, nil, nil, nil, nil, use_ssl: false)
       SsrfFilter.fetch_once(URI('http://www.example.com'), public_ipv4.to_s, :get, {})
     end
 
     it 'should use tls for https urls' do
-      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 443, use_ssl: true)
+      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 443, nil, nil, nil, nil, use_ssl: true)
       SsrfFilter.fetch_once(URI('https://www.example.com'), public_ipv4.to_s, :get, {})
+    end
+
+    it 'should set the proxy address' do
+      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 80, 'localhost', 8080, 'foo', 'bar', use_ssl: false)
+      SsrfFilter.fetch_once(
+        URI('http://www.example.com'), public_ipv4.to_s, :get, proxy: 'http://foo:bar@localhost:8080'
+      )
     end
   end
 


### PR DESCRIPTION
By default `Net::HTTP` will use `ENV['HTTP_PROXY']` for configuring a HTTP proxy for request. However we are facing a situation where we want to configure a proxy for a request without globally setting this environment variable.

This change allows an explicit proxy string to be included in an `SsrfFilter` request. It will fallback to the `ENV['HTTP_PROXY']` value if not provided.

N.B. An explicit proxy can be set with `OpenURI`, and proposal #35 would also solve this situation.