### PR TITLE
feat[patch]: support for patch verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ response.body
 
 ### API reference
 
-`SsrfFilter.get/.put/.post/.delete/.head(url, options = {}, &block)`
+`SsrfFilter.get/.put/.post/.delete/.head/.patch(url, options = {}, &block)`
 
 Fetches the requested url using a get/put/post/delete/head request, respectively.
 

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -77,7 +77,8 @@ class SsrfFilter
     put: ::Net::HTTP::Put,
     post: ::Net::HTTP::Post,
     delete: ::Net::HTTP::Delete,
-    head: ::Net::HTTP::Head
+    head: ::Net::HTTP::Head,
+    patch: ::Net::HTTP::Patch,
   }.freeze
 
   FIBER_LOCAL_KEY = :__ssrf_filter_hostname
@@ -100,7 +101,7 @@ class SsrfFilter
   class CRLFInjection < Error
   end
 
-  %i[get put post delete head].each do |method|
+  %i[get put post delete head patch].each do |method|
     define_singleton_method(method) do |url, options = {}, &block|
       ::SsrfFilter::Patch::SSLSocket.apply!
       ::SsrfFilter::Patch::HTTPGenericRequest.apply!

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -78,7 +78,7 @@ class SsrfFilter
     post: ::Net::HTTP::Post,
     delete: ::Net::HTTP::Delete,
     head: ::Net::HTTP::Head,
-    patch: ::Net::HTTP::Patch,
+    patch: ::Net::HTTP::Patch
   }.freeze
 
   FIBER_LOCAL_KEY = :__ssrf_filter_hostname

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -104,7 +104,7 @@ describe SsrfFilter do
 
     it 'should be able to make a patch request' do
       stub_request(:patch, "https://#{public_ipv4}").to_return(status: 200, body: 'response body')
-      response = SsrfFilter.fetch_once(URI('https://www.example.com'), public_ipv4.to_s, :put, {})
+      response = SsrfFilter.fetch_once(URI('https://www.example.com'), public_ipv4.to_s, :patch, {})
       expect(response.code).to eq('200')
       expect(response.body).to eq('response body')
     end

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -102,6 +102,13 @@ describe SsrfFilter do
       expect(response.body).to eq('response body')
     end
 
+    it 'should be able to make a patch request' do
+      stub_request(:patch, "https://#{public_ipv4}").to_return(status: 200, body: 'response body')
+      response = SsrfFilter.fetch_once(URI('https://www.example.com'), public_ipv4.to_s, :put, {})
+      expect(response.code).to eq('200')
+      expect(response.body).to eq('response body')
+    end
+
     it 'should pass headers, params, and blocks' do
       stub_request(:get, "https://#{public_ipv4}/?key=value").with(headers:
         {host: 'www.example.com', header: 'value', header2: 'value2'}).to_return(status: 200, body: 'response body')

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
-  gem.add_development_dependency('psych', '>= 2')
+  gem.add_development_dependency('psych', '>= 2', '< 4')
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '>= 3.5.1')
   gem.add_development_dependency('webrick') if major >= 3

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
-  gem.add_development_dependency('psych', '>= 2', '< 4')
+  gem.add_development_dependency('psych', '< 4')
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '>= 3.5.1')
   gem.add_development_dependency('webrick') if major >= 3

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
     # ssrf_filter doesn't use public_suffix directly, it's required by `addressable` which is required
     # by `webmock`. We need to set this requirement here to pin a version that is compatible with ruby 2.0
     gem.add_development_dependency('public_suffix', '2.0.5')
-    gem.add_development_dependency('rexml' '3.2.4')
+    gem.add_development_dependency('rexml', '3.2.4')
     gem.add_development_dependency('rubocop', '~> 0.50.0')
   end
 end

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
     # ssrf_filter doesn't use public_suffix directly, it's required by `addressable` which is required
     # by `webmock`. We need to set this requirement here to pin a version that is compatible with ruby 2.0
     gem.add_development_dependency('public_suffix', '2.0.5')
+    gem.add_development_dependency('rexml' '3.2.4')
     gem.add_development_dependency('rubocop', '~> 0.50.0')
   end
 end

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
-  gem.add_development_dependency('psych', '~> 3')
+  gem.add_development_dependency('psych', '>= 2')
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '>= 3.5.1')
   gem.add_development_dependency('webrick') if major >= 3

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
-  gem.add_development_dependency('psych', '~> 3.3.2')
+  gem.add_development_dependency('psych', '~> 3')
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '>= 3.5.1')
   gem.add_development_dependency('webrick') if major >= 3

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.6.1')
   gem.add_development_dependency('coveralls', '~> 0.8.22')
+  gem.add_development_dependency('psych', '~> 3.3.2')
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '>= 3.5.1')
   gem.add_development_dependency('webrick') if major >= 3


### PR DESCRIPTION
This PR adds support for the "patch" verb. This would allow you to be able to call:

~~~ruby
response = SsrfFilter.patch(params[:url]) # throws an exception for unsafe fetches
~~~

This PR resolves #38 . I needed to also update the maximum version of "psych" because 4.0 introduced a breaking change for YAML files with dates in them: https://github.com/ruby/psych/issues/489