### PR TITLE
Expose unsafe_ip_address? method

### DIFF
--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -150,7 +150,6 @@ class SsrfFilter
 
     true
   end
-  private_class_method :unsafe_ip_address?
 
   def self.ipaddr_has_mask?(ipaddr)
     range = ipaddr.to_range


### PR DESCRIPTION
We think this change would be useful for anyone who's looking to protect against SSRF but keep using their own code for performing the web requests. In our case, we're using Faraday with some instrumentation that would be tricky to put setup in the context of this gem.

The `unsafe_ip_address?` method is already covered by specs so it doesn't seem necessary to do anything other than removing the private modifier (?)