### PR TITLE
Add support to pass through `Net::HTTP.start` proxy params

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Options hash:
 - `:params` — Hash of params to send with the request.
 - `:headers` — Hash of headers to send with the request.
 - `:body` — Body to send with the request.
+- `:proxy` — Optional proxy parameters `:p_addr`, `:p_port`, `:p_user`, `:p_pass` same as you'd pass to [Net::HTTP.start](https://ruby-doc.org/stdlib-2.6.4/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start) for routing requests through a proxy.
 - `:http_options` – Options to pass to [Net::HTTP.start](https://ruby-doc.org/stdlib-2.6.4/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start). Use this to set custom timeouts or SSL options.
 
 Returns:

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -191,11 +191,21 @@ class SsrfFilter
     block.call(request) if block_given?
     validate_request(request)
 
+    proxy = options[:proxy] || {}
+
     http_options = options[:http_options] || {}
     http_options[:use_ssl] = (uri.scheme == 'https')
 
     with_forced_hostname(hostname) do
-      ::Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
+      ::Net::HTTP.start(
+        uri.hostname,
+        uri.port,
+        proxy[:p_addr],
+        proxy[:p_port],
+        proxy[:p_user],
+        proxy[:p_pass],
+        http_options,
+      ) do |http|
         http.request(request)
       end
     end

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -204,7 +204,7 @@ class SsrfFilter
         proxy[:p_port],
         proxy[:p_user],
         proxy[:p_pass],
-        http_options,
+        http_options
       ) do |http|
         http.request(request)
       end

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -107,7 +107,13 @@ describe SsrfFilter do
         {host: 'www.example.com', header: 'value', header2: 'value2'}).to_return(status: 200, body: 'response body')
       options = {
         headers: {'header' => 'value'},
-        params: {'key' => 'value'}
+        params: {'key' => 'value'},
+        proxy: {
+          p_addr: '127.0.0.1',
+          p_port: '12345',
+          p_user: 'guest',
+          p_pass: 'password',
+        },
       }
       uri = URI('https://www.example.com/?key=value')
       response = SsrfFilter.fetch_once(uri, public_ipv4.to_s, :get, options) do |req|

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -127,12 +127,12 @@ describe SsrfFilter do
     end
 
     it 'should not use tls for http urls' do
-      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 80, use_ssl: false)
+      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 80, nil, nil, nil, nil, use_ssl: false)
       SsrfFilter.fetch_once(URI('http://www.example.com'), public_ipv4.to_s, :get, {})
     end
 
     it 'should use tls for https urls' do
-      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 443, use_ssl: true)
+      expect(::Net::HTTP).to receive(:start).with(public_ipv4.to_s, 443, nil, nil, nil, nil, use_ssl: true)
       SsrfFilter.fetch_once(URI('https://www.example.com'), public_ipv4.to_s, :get, {})
     end
   end

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -112,8 +112,8 @@ describe SsrfFilter do
           p_addr: '127.0.0.1',
           p_port: '12345',
           p_user: 'guest',
-          p_pass: 'password',
-        },
+          p_pass: 'password'
+        }
       }
       uri = URI('https://www.example.com/?key=value')
       response = SsrfFilter.fetch_once(uri, public_ipv4.to_s, :get, options) do |req|


### PR DESCRIPTION
### Description

`Net::HTTP` accepts proxy parameters but `ssrf_filter` doesn't allow passing them through. This PR adds a `:proxy` value to the options hash, such that a request might look like

```ruby
response = SsrfFilter.get(
  'https://ipinfo.io',
  proxy: {
    p_addr: proxy_addr,
    p_port: proxy_port,
    p_user: proxy_user,
    p_pass: proxy_password,
  }
)
```