### PR TITLE
Add Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,10 +8,10 @@ jobs:
   build-test:
     strategy:
       matrix:
-        ruby-version: [2.6.0, 2.7.0, 3.0.0, 3.1.0, head]
+        ruby-version: [2.6.0, 2.7.0, 3.0.0, 3.1.0, 3.2.0, head]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}

--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('bundler-audit', '~> 0.9.1')
   gem.add_development_dependency('pry-byebug')
-  gem.add_development_dependency('rspec', '~> 3.11.0')
+  gem.add_development_dependency('rspec', '~> 3.12.0')
   gem.add_development_dependency('rubocop', '~> 1.35.0')
   gem.add_development_dependency('rubocop-rspec', '~> 2.12.1')
-  gem.add_development_dependency('simplecov', '~> 0.21.2')
+  gem.add_development_dependency('simplecov', '~> 0.22.0')
   gem.add_development_dependency('simplecov-lcov', '~> 0.8.0')
   gem.add_development_dependency('webmock', '>= 3.18.0')
   gem.add_development_dependency('webrick')


### PR DESCRIPTION
Updated a few development dependencies for Ruby 3.2 compatibility.  Also updated the checkout action version.

Runs green on my fork.