### PR TITLE
Fix resolv IP regex patch for case when comapred strings are not the same object

### DIFF
--- a/lib/ssrf_filter/patch/resolv.rb
+++ b/lib/ssrf_filter/patch/resolv.rb
@@ -21,7 +21,7 @@ class SsrfFilter
       class PatchedRegexp < Regexp
         def ===(other)
           if ::Thread.current.key?(::SsrfFilter::FIBER_ADDRESS_KEY) &&
-             other.object_id.equal?(::Thread.current[::SsrfFilter::FIBER_ADDRESS_KEY].object_id)
+             other.eql?(::Thread.current[::SsrfFilter::FIBER_ADDRESS_KEY])
             false
           else
             super(other)

--- a/spec/lib/patch/resolv_spec.rb
+++ b/spec/lib/patch/resolv_spec.rb
@@ -32,7 +32,7 @@ describe ::SsrfFilter::Patch::Resolv do
 
     it 'forces the ip regex to not match the same supplied address' do
       ip_address = '1.2.3.4'
-      same_ip_address = '1.2.3.4'
+      same_ip_address = '1.2.3.4'.clone
       SsrfFilter.send(:with_forced_hostname, nil, ip_address) do
         expect(described_class.new(Resolv::IPv4::Regex) === same_ip_address).to be false
       end

--- a/spec/lib/patch/resolv_spec.rb
+++ b/spec/lib/patch/resolv_spec.rb
@@ -29,5 +29,14 @@ describe ::SsrfFilter::Patch::Resolv do
       expect(described_class.new(Resolv::IPv4::Regex) === ipaddress2).to be true
       # rubocop:enable Style/CaseEquality
     end
+
+    it 'forces the ip regex to not match the same supplied address' do
+      ip_address = '1.2.3.4'
+      same_ip_address = '1.2.3.4'
+      SsrfFilter.send(:with_forced_hostname, nil, ip_address) do
+        expect(described_class.new(Resolv::IPv4::Regex) === same_ip_address).to be false
+      end
+      expect(described_class.new(Resolv::IPv4::Regex) === same_ip_address).to be true
+    end
   end
 end


### PR DESCRIPTION
`uri.hostname` returns new object on every call if hostname is IPv6 string 

```
irb(main):001:0> require "uri"
=> true
irb(main):002:0> uri = URI("https://example.com")
=> #<URI::HTTPS https://example.com>
irb(main):003:0> uri.hostname = "2a02:a31a:e13c:b400:bc2b:aa4f:f1e4:5f57"
=> "2a02:a31a:e13c:b400:bc2b:aa4f:f1e4:5f57"
irb(main):004:0> uri.hostname.object_id
=> 37460
irb(main):005:0> uri.hostname.object_id
=> 40400
irb(main):006:0> uri.hostname.object_id
=> 43340
irb(main):007:0> uri.hostname = "88.62.42.210"
=> "88.62.42.210"
irb(main):008:0> uri.hostname.object_id
=> 72160
irb(main):009:0> uri.hostname.object_id
=> 72160
irb(main):010:0> uri.hostname.object_id
=> 72160
```

Because of this, comparing of `ip` and `uri.hostname` from [`lib/ssrf_filter/ssrf_filter.rb#L192-L193`](https://github.com/arkadiyt/ssrf_filter/blob/f93dab191a180a4dfcd7e6f2d526fd1e73aae32f/lib/ssrf_filter/ssrf_filter.rb#L192-L193) in [`lib/ssrf_filter/patch/resolv.rb#L24`](https://github.com/arkadiyt/ssrf_filter/blob/f93dab191a180a4dfcd7e6f2d526fd1e73aae32f/lib/ssrf_filter/patch/resolv.rb#L24) returns `true`.

And the patch does not work.