### PR TITLE
setting custom user agent

### DIFF
--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -191,6 +191,7 @@ class SsrfFilter
 
     with_forced_hostname(hostname, ip) do
       ::Net::HTTP.start(uri.hostname, uri.port, **http_options) do |http|
+        request['User-Agent'] = 'ssrf_filter/1.0'
         http.request(request) do |response|
           case response
           when ::Net::HTTPRedirection


### PR DESCRIPTION
I've created [this issue](https://github.com/arkadiyt/ssrf_filter/issues/67) to explain the issue but basically the default user-agent has the "ruby" word on it and it causes some sites to raise the error "EOFError (end of file reached)".

Setting the user-agent to "ssrf_filter/1.0" fixes the issue.