### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/ssrf_filter

### DIFF
--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'https://github.com/arkadiyt/ssrf_filter'
   gem.license     = 'MIT'
   gem.files       = Dir['lib/**/*.rb']
-  gem.metadata    = {'rubygems_mfa_required' => 'true'}
+  gem.metadata    = {'changelog_uri' => "#{gem.homepage}/blob/main/CHANGELOG.md",
+                     'rubygems_mfa_required' => 'true'}
 
   gem.add_development_dependency('base64', '~> 0.2.0') # For ruby >= 3.4
   gem.add_development_dependency('bundler-audit', '~> 0.9.2')


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/ssrf_filter which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata