### PR TITLE
Don't send sensitive headers on cross origin redirects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Naming/MethodParameterName:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/CaseIndentation:
   EnforcedStyle: end
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Options hash:
 - `:http_options` – Options to pass to [Net::HTTP.start](https://ruby-doc.org/stdlib-2.6.4/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start). Use this to set custom timeouts or SSL options.
 - `:request_proc` - a proc that receives the request object, for custom modifications before sending the request.
 - `:allow_unfollowed_redirects` - If true and your request hits the maximum number of redirects, the last response will be returned instead of raising an error. Defaults to false.
+- `:sensitive_headers` — array of header names (case-insensitive) that will not be forwarded when following a cross-origin redirect (when the scheme, host, or port changes). Defaults to `%w[authorization cookie]`. Pass `[]` to disable this protection.
+- `:on_cross_origin_redirect` — controls behavior when a cross-origin redirect would send sensitive headers. `:strip` (default) silently removes them and follows the redirect; `:raise` raises `SsrfFilter::CredentialLeakage` instead.
 
 Returns:
 

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -91,6 +91,8 @@ class SsrfFilter
 
   DEFAULT_ALLOW_UNFOLLOWED_REDIRECTS = false
   DEFAULT_MAX_REDIRECTS = 10
+  DEFAULT_SENSITIVE_HEADERS = %w[authorization cookie].freeze
+  DEFAULT_ON_CROSS_ORIGIN_REDIRECT = :strip
 
   VERB_MAP = {
     get: ::Net::HTTP::Get,
@@ -119,14 +121,19 @@ class SsrfFilter
   class CRLFInjection < Error
   end
 
+  class CredentialLeakage < Error
+  end
+
   VERB_MAP.each_key do |method|
     define_singleton_method(method) do |url, options = {}, &block|
+      url = url.to_s
       original_url = url
+      original_uri = URI(url)
       scheme_whitelist = options.fetch(:scheme_whitelist, DEFAULT_SCHEME_WHITELIST)
       resolver = options.fetch(:resolver, DEFAULT_RESOLVER)
       allow_unfollowed_redirects = options.fetch(:allow_unfollowed_redirects, DEFAULT_ALLOW_UNFOLLOWED_REDIRECTS)
       max_redirects = options.fetch(:max_redirects, DEFAULT_MAX_REDIRECTS)
-      url = url.to_s
+      sensitive_headers = options.fetch(:sensitive_headers, DEFAULT_SENSITIVE_HEADERS)
 
       response = nil
       (max_redirects + 1).times do
@@ -143,7 +150,14 @@ class SsrfFilter
         public_addresses = ip_addresses.reject(&method(:unsafe_ip_address?))
         raise PrivateIPAddress, "Hostname '#{hostname}' has no public ip addresses" if public_addresses.empty?
 
-        response, url = fetch_once(uri, public_addresses.sample.to_s, method, options, &block)
+        headers_to_strip = if !sensitive_headers.empty? && different_origin?(original_uri, uri)
+          sensitive_headers
+        else
+          []
+        end
+
+        response, url = fetch_once(uri, public_addresses.sample.to_s, method,
+          options.merge(headers_to_strip: headers_to_strip), &block)
         return response if url.nil?
       end
 
@@ -178,6 +192,10 @@ class SsrfFilter
     range.first != range.last
   end
 
+  private_class_method def self.different_origin?(uri1, uri2)
+    uri1.scheme != uri2.scheme || uri1.hostname != uri2.hostname || uri1.port != uri2.port
+  end
+
   private_class_method def self.normalized_hostname(uri)
     # Attach port for non-default as per RFC2616
     if (uri.port == 80 && uri.scheme == 'http') ||
@@ -205,6 +223,20 @@ class SsrfFilter
     request.body = options[:body] if options[:body]
 
     options[:request_proc].call(request) if options[:request_proc].respond_to?(:call)
+
+    headers_to_strip = Array(options[:headers_to_strip])
+    unless headers_to_strip.empty?
+      if options[:on_cross_origin_redirect] == :raise
+        leaking = headers_to_strip.select { |h| request[h] }
+        unless leaking.empty?
+          raise CredentialLeakage,
+            "Cross-origin redirect would leak sensitive headers: #{leaking.join(', ')}"
+        end
+      else
+        headers_to_strip.each { |h| request.delete(h) }
+      end
+    end
+
     validate_request(request)
 
     http_options = (options[:http_options] || {}).merge(

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -522,11 +522,50 @@ describe SsrfFilter do
 
     it 'follows relative redirects and succeed' do
       stub_request(:post, 'https://www.example.com/path?key=value').to_return(status: 301,
-                                                                              headers: {location: '/path2?key2=value2'})
+        headers: {location: '/path2?key2=value2'})
       stub_request(:post, 'https://www.example.com/path2?key2=value2').to_return(status: 200, body: 'response body')
       response = described_class.post('https://www.example.com/path?key=value')
       expect(response.code).to eq('200')
       expect(response.body).to eq('response body')
+    end
+
+    it 'strips sensitive headers set via request_proc on cross-origin redirect' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301, headers: {location: 'https://www.example2.com/'})
+      stub_request(:get, 'https://www.example2.com/').to_return(status: 200)
+      auth_header = {'Authorization' => 'Bearer token'}
+      request_proc = proc { |req| req['Authorization'] = 'Bearer token' }
+      described_class.get('https://www.example.com/', request_proc: request_proc)
+      expect(a_request(:get, 'https://www.example2.com/').with(headers: auth_header)).not_to have_been_made
+      expect(a_request(:get, 'https://www.example2.com/')).to have_been_made
+    end
+
+    it 'raises CredentialLeakage on cross-origin redirect when on_cross_origin_redirect is :raise' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301, headers: {location: 'https://www.example2.com/'})
+      stub_request(:get, 'https://www.example2.com/').to_return(status: 200)
+      expect do
+        described_class.get('https://www.example.com/', headers: {'Authorization' => 'Bearer token'},
+          on_cross_origin_redirect: :raise)
+      end.to raise_error(described_class::CredentialLeakage)
+    end
+
+    it 'preserves sensitive headers for same-origin hops but strips them on a subsequent cross-origin hop' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301, headers: {location: 'https://www.example.com/other'})
+      stub_request(:get, 'https://www.example.com/other').to_return(status: 301, headers: {location: 'https://www.example2.com/'})
+      stub_request(:get, 'https://www.example2.com/').to_return(status: 200)
+      auth_header = {'Authorization' => 'Bearer token'}
+      described_class.get('https://www.example.com/', headers: auth_header)
+      expect(a_request(:get, 'https://www.example.com/other').with(headers: auth_header)).to have_been_made
+      expect(a_request(:get, 'https://www.example2.com/').with(headers: auth_header)).not_to have_been_made
+    end
+
+    it 'strips sensitive headers on a same-origin redirect after an earlier cross-origin redirect' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301, headers: {location: 'https://www.example2.com/'})
+      stub_request(:get, 'https://www.example2.com/').to_return(status: 301, headers: {location: 'https://www.example2.com/other'})
+      stub_request(:get, 'https://www.example2.com/other').to_return(status: 200)
+      auth_header = {'Authorization' => 'Bearer token'}
+      described_class.get('https://www.example.com/', headers: auth_header)
+      expect(a_request(:get, 'https://www.example2.com/').with(headers: auth_header)).not_to have_been_made
+      expect(a_request(:get, 'https://www.example2.com/other').with(headers: auth_header)).not_to have_been_made
     end
   end
 end


### PR DESCRIPTION
Previously if you were sending authorization/cookie/etc headers to an endpoint and received a redirect to a new origin, this library would send all the original headers to that redirected location. With this PR the library will now either strip those sensitive headers out on cross origin redirects or raise an exception. This brings it inline with behavior from e.g. browsers and curl.

Reported by [xkiluar](https://hackerone.com/xkiluar)