### PR TITLE
Resolve redirect Location URI references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Resolve all redirect `Location` URI-reference forms against the request URI
+
 ### 1.5.0 (4/2/2026)
 * Fix an issue where sensitive headers could have been sent to unintended origins during redirects ([xkiluar](https://hackerone.com/xkiluar), [arkadiyt](https://github.com/arkadiyt/ssrf_filter/pull/86))
 

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -280,9 +280,10 @@ class SsrfFilter
       end
       case response
       when ::Net::HTTPRedirection
-        url = response['location']
-        # Handle relative redirects
-        url = "#{uri.scheme}://#{normalized_hostname(uri)}#{url}" if url&.start_with?('/')
+        location = response['location']
+        # RFC 9110 s10.2.2: Location is a URI-reference, resolved against the request URI
+        # according to RFC 3986 s5.
+        url = location && ::URI.join(uri, location).to_s
       else
         url = nil
       end

--- a/spec/lib/ssrf_filter_spec.rb
+++ b/spec/lib/ssrf_filter_spec.rb
@@ -624,13 +624,68 @@ describe SsrfFilter do
       expect(response.body).to eq('response body')
     end
 
-    it 'follows relative redirects and succeed' do
+    it 'follows root-relative redirects and succeeds' do
       stub_request(:post, 'https://www.example.com/path?key=value').to_return(status: 301,
         headers: {location: '/path2?key2=value2'})
       stub_request(:post, 'https://www.example.com/path2?key2=value2').to_return(status: 200, body: 'response body')
       response = described_class.post('https://www.example.com/path?key=value')
       expect(response.code).to eq('200')
       expect(response.body).to eq('response body')
+    end
+
+    it 'follows path-relative redirects' do
+      stub_request(:get, 'https://www.example.com/start/page').to_return(status: 301,
+        headers: {location: 'final'})
+      stub_request(:get, 'https://www.example.com/start/final').to_return(status: 200, body: 'response body')
+      response = described_class.get('https://www.example.com/start/page')
+      expect(response.code).to eq('200')
+      expect(response.body).to eq('response body')
+    end
+
+    it 'resolves dot segments in redirects' do
+      stub_request(:get, 'https://www.example.com/start/page').to_return(status: 301,
+        headers: {location: '../contact'})
+      stub_request(:get, 'https://www.example.com/contact').to_return(status: 200, body: 'response body')
+      response = described_class.get('https://www.example.com/start/page')
+      expect(response.code).to eq('200')
+      expect(response.body).to eq('response body')
+    end
+
+    it 'follows query-only redirects' do
+      stub_request(:get, 'https://www.example.com/start/page').to_return(status: 301,
+        headers: {location: '?page=2'})
+      stub_request(:get, 'https://www.example.com/start/page?page=2').to_return(status: 200, body: 'response body')
+      response = described_class.get('https://www.example.com/start/page')
+      expect(response.code).to eq('200')
+      expect(response.body).to eq('response body')
+    end
+
+    it 'validates the host in a protocol-relative redirect' do
+      stub_request(:get, 'https://www.example.com/start').to_return(status: 301,
+        headers: {location: '//private.example.com/page'})
+      resolver = proc { |hostname| hostname == 'www.example.com' ? [public_ipv4] : [private_ipv4] }
+      expect do
+        described_class.get('https://www.example.com/start', resolver: resolver)
+      end.to raise_error(described_class::PrivateIPAddress, /private\.example\.com/)
+      expect(a_request(:get, 'https://private.example.com/page')).not_to have_been_made
+    end
+
+    it 'strips sensitive headers on a protocol-relative cross-origin redirect' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301,
+        headers: {location: '//www.example2.com/page'})
+      stub_request(:get, 'https://www.example2.com/page').to_return(status: 200)
+      auth_header = {'Authorization' => 'Bearer token'}
+      described_class.get('https://www.example.com/', headers: auth_header)
+      expect(a_request(:get, 'https://www.example2.com/page').with(headers: auth_header)).not_to have_been_made
+      expect(a_request(:get, 'https://www.example2.com/page')).to have_been_made
+    end
+
+    it 'raises URI::InvalidURIError for a malformed redirect location' do
+      stub_request(:get, 'https://www.example.com/').to_return(status: 301,
+        headers: {location: 'http://[invalid'})
+      expect do
+        described_class.get('https://www.example.com/')
+      end.to raise_error(URI::InvalidURIError)
     end
 
     it 'strips sensitive headers set via request_proc on cross-origin redirect' do


### PR DESCRIPTION
## Summary

Resolve redirect `Location` values as URI-references against the request URI with `URI.join`, as required by [RFC 9110 §10.2.2](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.2) and [RFC 3986 §5](https://www.rfc-editor.org/rfc/rfc3986#section-5).

This completes the relative redirect support introduced in #13. That implementation handles root-relative references, but path-relative (`final`), dot-segment (`../contact`), and query-only (`?page=2`) references currently fail with `InvalidUriScheme`. Protocol-relative references (`//other.example/page`) are silently interpreted as a path on the original host instead of a redirect to `other.example`.

```
What HTTP redirects can legally look like (all standards-compliant for a website to send):

┌───────────────────────────┬──────────────────────────────────────────────────┐
│      Location value       │                     Meaning                      │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ https://example.com/final │ absolute — go exactly here                       │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ /final                    │ root-relative — same host, this path             │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ final, ../contact         │ path-relative — resolve against the current path │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ //other.example/page      │ protocol-relative — same scheme, different host  │
├───────────────────────────┼──────────────────────────────────────────────────┤
│ ?page=2                   │ query-only — same page, new query                │
└───────────────────────────┴──────────────────────────────────────────────────┘
```

Correct protocol-relative resolution also lets the cross-origin sensitive-header handling added in 1.5.0 recognize these hops correctly. This is not an SSRF bypass: each resolved destination still goes through the existing resolve-and-validate loop before it is fetched.

## Error behavior

A malformed `Location` now raises `URI::InvalidURIError` from `URI.join`, rather than reaching the next loop iteration and raising `SsrfFilter::InvalidUriScheme`. I left the stdlib error intact rather than treating a malformed redirect as unfollowable, but I am happy to adjust that behavior if another approach is preferred.

## Tests

Added coverage for:

- path-relative redirects
- dot-segment redirects
- query-only redirects
- protocol-relative redirects, including destination IP validation
- sensitive-header stripping on protocol-relative cross-origin redirects
- malformed `Location` values
- existing absolute and root-relative behavior

Local checks:

- `bundle exec rspec` (57 examples, 100% line coverage)
- `bundle exec rubocop`
- `bundle exec bundler-audit check --update`
